### PR TITLE
Add: Install the GitHub CLI.

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y --no-install-recommends \
     sagemath \
     ghostscript \
     pdf2svg \
-    pandoc 
+    pandoc
 
 # Set up virtual environment
 # ENV VIRTUAL_ENV=/opt/venv
@@ -15,3 +15,11 @@ RUN apt update && apt install -y --no-install-recommends \
 RUN pip install pretext codechat-server
 
 RUN playwright install-deps
+
+# Install the GitHub CLI; taken from the [docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt).
+type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& sudo apt update \
+&& sudo apt install gh -y

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,6 +1,13 @@
 FROM python:3
 
-RUN apt update && apt install -y --no-install-recommends pandoc 
+RUN apt update && apt install -y --no-install-recommends pandoc
 
 RUN pip install pretext codechat-server
 
+# Install the GitHub CLI; taken from the [docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt).
+type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& sudo apt update \
+&& sudo apt install gh -y

--- a/small/Dockerfile
+++ b/small/Dockerfile
@@ -7,6 +7,14 @@ RUN apt update && apt install -y --no-install-recommends \
     texlive texlive-science texlive-xetex \
     ghostscript \
     pdf2svg \
-    pandoc 
+    pandoc
 
 RUN playwright install-deps
+
+# Install the GitHub CLI; taken from the [docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt).
+type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& sudo apt update \
+&& sudo apt install gh -y


### PR DESCRIPTION
The GitHub CLI is needed by the CodeChat Server to make the websocket port it uses public. The `devcontainer.json` file doesn't provide a way to set a port's visibility.